### PR TITLE
fix: runtime error: index out of range [0] with length 0

### DIFF
--- a/lib/jrpc/pool.go
+++ b/lib/jrpc/pool.go
@@ -2,10 +2,11 @@ package jrpc
 
 import (
 	"context"
+	"sync"
+
 	"github.com/rs/zerolog/log"
 	strings2 "github.com/weka/go-cloud-lib/lib/strings"
 	"github.com/weka/go-cloud-lib/lib/weka"
-	"sync"
 )
 
 type ClientBuilder func(ip string) *BaseClient
@@ -36,6 +37,10 @@ func (c *Pool) Drop(toDrop string) {
 }
 
 func (c *Pool) Call(method weka.JrpcMethod, params, result interface{}) (err error) {
+	if len(c.Ips) == 0 {
+		log.Debug().Msgf("Pool.Ips is empty")
+		return nil
+	}
 	if c.Active == "" {
 		c.Lock()
 		c.Active = c.Ips[0]


### PR DESCRIPTION
Addressing the panic:
```
2023-04-19T13:36:53Z   [Error]   {"level":"debug","time":"2023-04-19T13:36:52Z","message":"dropping 10.0.3.38 from pool"}
2023-04-19T13:36:54Z   [Error]   2023/04/19 13:36:52 http: panic serving 127.0.0.1:34378: runtime error: index out of range [0] with length 0
2023-04-19T13:36:54Z   [Error]   goroutine 2839 [running]:
2023-04-19T13:36:54Z   [Error]   net/http.(*conn).serve.func1()
2023-04-19T13:36:54Z   [Error]   	/snap/go/10135/src/net/http/server.go:1854 +0xbf
2023-04-19T13:36:54Z   [Error]   panic({0x944400, 0xc00002aa50})
2023-04-19T13:36:54Z   [Error]   	/snap/go/10135/src/runtime/panic.go:890 +0x263
2023-04-19T13:36:54Z   [Error]   github.com/weka/go-cloud-lib/lib/jrpc.(*Pool).Call(0xc0001c1020, {0x979e25, 0x6}, {0x8d1fc0, 0xd529e8}, {0x8a68e0, 0xc0000daa80})
2023-04-19T13:36:54Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/lib/jrpc/pool.go:41 +0x31f
2023-04-19T13:36:54Z   [Error]   github.com/weka/go-cloud-lib/lib/jrpc.(*Pool).Call(0xc0001c1020, {0x979e25, 0x6}, {0x8d1fc0, 0xd529e8}, {0x8a68e0, 0xc0000daa80})
2023-04-19T13:36:54Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/lib/jrpc/pool.go:49 +0x2eb
2023-04-19T13:36:54Z   [Error]   github.com/weka/go-cloud-lib/lib/jrpc.(*Pool).Call(0xc0001c1020, {0x979e25, 0x6}, {0x8d1fc0, 0xd529e8}, {0x8a68e0, 0xc0000daa80})
2023-04-19T13:36:54Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/lib/jrpc/pool.go:49 +0x2eb
2023-04-19T13:36:54Z   [Error]   github.com/weka/go-cloud-lib/lib/jrpc.(*Pool).Call(0xc0001c1020, {0x979e25, 0x6}, {0x8d1fc0, 0xd529e8}, {0x8a68e0, 0xc0000daa80})
2023-04-19T13:36:54Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/lib/jrpc/pool.go:49 +0x2eb
2023-04-19T13:36:54Z   [Error]   github.com/weka/go-cloud-lib/lib/jrpc.(*Pool).Call(0xc0001c1020, {0x979e25, 0x6}, {0x8d1fc0, 0xd529e8}, {0x8a68e0, 0xc0000daa80})
2023-04-19T13:36:54Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/lib/jrpc/pool.go:49 +0x2eb
2023-04-19T13:36:54Z   [Error]   github.com/weka/go-cloud-lib/lib/jrpc.(*Pool).Call(0xc0001c1020, {0x979e25, 0x6}, {0x8d1fc0, 0xd529e8}, {0x8a68e0, 0xc0000daa80})
2023-04-19T13:36:54Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/lib/jrpc/pool.go:49 +0x2eb
2023-04-19T13:36:54Z   [Error]   github.com/weka/go-cloud-lib/lib/jrpc.(*Pool).Call(0xc0001c1020, {0x979e25, 0x6}, {0x8d1fc0, 0xd529e8}, {0x8a68e0, 0xc0000daa80})
2023-04-19T13:36:54Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/lib/jrpc/pool.go:49 +0x2eb
2023-04-19T13:36:54Z   [Error]   github.com/weka/go-cloud-lib/lib/jrpc.(*Pool).Call(0xc0001c1020, {0x979e25, 0x6}, {0x8d1fc0, 0xd529e8}, {0x8a68e0, 0xc0000daa80})
2023-04-19T13:36:54Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/lib/jrpc/pool.go:49 +0x2eb
2023-04-19T13:36:54Z   [Error]   github.com/weka/go-cloud-lib/scale_down.ScaleDown({0xa3d578?, 0xc00047fc50}, {{0xc000447c60, 0x5}, {0xc000447c70, 0x10}, 0x7, {0xc00014f8c0, 0x7, 0x9}, ...})
2023-04-19T13:36:55Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/scale_down/scale_down.go:406 +0x45e
2023-04-19T13:36:55Z   [Error]   weka-deployment/functions/scale_down.Handler({0xa3d200, 0xc00030e8c0}, 0xc0002d1900)
2023-04-19T13:36:55Z   [Error]   	/home/denise/Documents/tmp/terraform-azure-weka/function-app/code/functions/scale_down/scale_down.go:42 +0x288
2023-04-19T13:36:55Z   [Error]   net/http.HandlerFunc.ServeHTTP(0xc0001c0f60?, {0xa3d200?, 0xc00030e8c0?}, 0x1f4?)
2023-04-19T13:36:55Z   [Error]   	/snap/go/10135/src/net/http/server.go:2122 +0x2f
2023-04-19T13:36:55Z   [Error]   github.com/weka/go-cloud-lib/logging.AzureFuncInvocationIdHandler.func1.1({0xa3d200, 0xc00030e8c0}, 0xc0002d1900)
2023-04-19T13:36:55Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/logging/middleware.go:35 +0x12d
2023-04-19T13:36:55Z   [Error]   net/http.HandlerFunc.ServeHTTP(0xc0001c0f60?, {0xa3d200?, 0xc00030e8c0?}, 0xf8?)
2023-04-19T13:36:55Z   [Error]   	/snap/go/10135/src/net/http/server.go:2122 +0x2f
2023-04-19T13:36:55Z   [Error]   github.com/weka/go-cloud-lib/logging.FuncNameHandler.func1.1({0xa3d200, 0xc00030e8c0}, 0xc0002d1900)
2023-04-19T13:36:55Z   [Error]   	/home/denise/go/pkg/mod/github.com/weka/go-cloud-lib@v0.0.0-20230330055052-b9fbdb43ca52/logging/middleware.go:21 +0xea
2023-04-19T13:36:55Z   [Error]   net/http.HandlerFunc.ServeHTTP(0xa3bf48?, {0xa3d200?, 0xc00030e8c0?}, 0x0?)
2023-04-19T13:36:55Z   [Error]   	/snap/go/10135/src/net/http/server.go:2122 +0x2f
2023-04-19T13:36:55Z   [Error]   github.com/rs/zerolog/hlog.NewHandler.func1.1({0xa3d200, 0xc00030e8c0}, 0xc0002d1800)
2023-04-19T13:36:55Z   [Error]   	/home/denise/go/pkg/mod/github.com/rs/zerolog@v1.29.0/hlog/hlog.go:29 +0x342
2023-04-19T13:36:55Z   [Error]   net/http.HandlerFunc.ServeHTTP(0xc00030e8c0?, {0xa3d200?, 0xc00030e8c0?}, 0xc0004473f0?)
2023-04-19T13:36:55Z   [Error]   	/snap/go/10135/src/net/http/server.go:2122 +0x2f
2023-04-19T13:36:55Z   [Error]   net/http.(*ServeMux).ServeHTTP(0x0?, {0xa3d200, 0xc00030e8c0}, 0xc0002d1800)
2023-04-19T13:36:55Z   [Error]   	/snap/go/10135/src/net/http/server.go:2500 +0x149
2023-04-19T13:36:55Z   [Error]   net/http.serverHandler.ServeHTTP({0xa3b6d8?}, {0xa3d200, 0xc00030e8c0}, 0xc0002d1800)
2023-04-19T13:36:55Z   [Error]   	/snap/go/10135/src/net/http/server.go:2936 +0x316
2023-04-19T13:36:55Z   [Error]   net/http.(*conn).serve(0xc0003595f0, {0xa3d578, 0xc000089b30})
2023-04-19T13:36:55Z   [Error]   	/snap/go/10135/src/net/http/server.go:1995 +0x612
2023-04-19T13:36:55Z   [Error]   created by net/http.(*Server).Serve
2023-04-19T13:36:56Z   [Error]   	/snap/go/10135/src/net/http/server.go:3089 +0x5ed
```